### PR TITLE
Add long line support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
     HAPROXY_VERSION=v1.7.3
 
 ADD syslog-stdout/ /usr/src/syslog-stdout
+ADD long-lines.patch /tmp/
 
 RUN apt-get update -yq && apt-get upgrade -yq && \
     apt-get install -yq --no-install-recommends inotify-tools ca-certificates build-essential \
@@ -19,6 +20,7 @@ RUN apt-get update -yq && apt-get upgrade -yq && \
     HAPROXY_PATH=/usr/src/haproxy && LIBRESSL_PATH=/usr/src/libressl-${LIBRESSL_VERSION} && LIBSLZ_PATH=/usr/src/libslz && \
       git clone --branch ${HAPROXY_VERSION} http://git.haproxy.org/git/haproxy-1.7.git/ ${HAPROXY_PATH} && \
       cd $HAPROXY_PATH && \
+      git apply /tmp/long-lines.patch && \
       make TARGET=custom CPU=native USE_PCRE=1 USE_PCRE_JIT=1 USE_LIBCRYPT=1 USE_LINUX_SPLICE=1 USE_LINUX_TPROXY=1 \
          USE_GETADDRINFO=1 USE_STATIC_PCRE=1 USE_TFO=1 \
          USE_SLZ=1 SLZ_INC=${LIBSLZ_PATH}/src SLZ_LIB=${LIBSLZ_PATH} \

--- a/long-lines.patch
+++ b/long-lines.patch
@@ -1,0 +1,30 @@
+From cf6234ae7c40630c9a2e1135c1a58a3489015604 Mon Sep 17 00:00:00 2001
+From: Jon Penn <Jon@Qbox.io>
+Date: Sat, 10 Mar 2018 02:54:10 -0600
+Subject: [PATCH] make config lines longer for long ip lists
+
+---
+ include/common/defaults.h | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/include/common/defaults.h b/include/common/defaults.h
+index 9f2c2236..8b251bbb 100644
+--- a/include/common/defaults.h
++++ b/include/common/defaults.h
+@@ -68,11 +68,11 @@
+ 
+ // maximum line size when parsing config
+ #ifndef LINESIZE
+-#define LINESIZE	2048
++#define LINESIZE	20480
+ #endif
+ 
+ // max # args on a configuration line
+-#define MAX_LINE_ARGS   64
++#define MAX_LINE_ARGS   640
+ 
+ // crt-list parsing factor for LINESIZE and MAX_LINE_ARGS
+ #define CRTLIST_FACTOR  32
+-- 
+2.16.1
+


### PR DESCRIPTION
We have really long lines in the config file sometimes because of
the ip whitelist. This just adds a patch to alter the defaults file
so the max line length is 10x it's default value. This might could
be done via an option to make insted, which would be cleaner.